### PR TITLE
make adding a new book work again

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -33,7 +33,7 @@ class Book < Item
 	end
 
 	def self.new_from_isbn(isbn)
-		isbn = isbn.gsub /[- ]/, ''
+		isbn = Isbn.new(isbn) unless isbn.is_a? Isbn
 		isbndb_data = IsbnDbClient.new(isbn).get_data
 		google_data = GoogleBooksClient.new(isbn).get_data
 

--- a/test/unit/book_test.rb
+++ b/test/unit/book_test.rb
@@ -4,7 +4,7 @@ class BookTest < ActiveSupport::TestCase
   def test_new_from_isbn
     shne = Book.new_from_isbn('0-385-66004-9')
 
-    assert_equal '0385660049', shne.isbn
+    assert_equal '0385660049', shne.isbn.to_s
     assert_equal 'A Short History of Nearly Everything', shne.title
     assert_equal 'Bryson', shne.author_last
     assert_equal 'Bill', shne.author_first


### PR DESCRIPTION
Initially I didn't realise that there was an Isbn class handling normalisation, and I broke adding a new book, supposing `isbn` was a string.
