### PR TITLE
allow to serve cover images by Google

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -24,7 +24,7 @@ class BooksController < ItemsController
 		else
 			super
 
-			@item.fetch_cover_image
+			@item.fetch_cover_image if AppConfig.fetch_covers
 		end
 	end
 
@@ -58,7 +58,8 @@ class BooksController < ItemsController
 				:isbn =>         @item.isbn,
 				:lcc_number =>	 @item.lcc_number,
 				:author_last =>	 @item.author_last,
-				:author_first => @item.author_first
+				:author_first => @item.author_first,
+				:cover_url =>    @item.cover_url
 			},
 			:tags => @item.tags
 	end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -89,6 +89,6 @@ module ApplicationHelper
 	end
 
 	def cover_photo item
-		image_tag "/images/items/books/#{item.isbn}.jpg", :class => 'cover_photo', :alt => ''
+		image_tag item.cover_url, :class => 'cover_photo', :alt => ''
 	end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -20,8 +20,16 @@ class NoSuchISBN < RuntimeError; end
 class Book < Item
 	COVER_IMG_DIR = 'public/images/items/books/'
 
+	def cover_url
+		if self.isbn.present? and File.exists? self.cover_filename
+			self.cover_filename
+		else
+			self[:cover_url]
+		end
+	end
+
 	def has_cover_image?
-		self.isbn and not self.isbn.empty? and File.exists? self.cover_filename
+		cover_url.present?
 	end
 
 	def cover_filename
@@ -52,6 +60,7 @@ class Book < Item
 		book.description  = data[:description]
 		book.author_first = data[:author_first]
 		book.author_last  = data[:author_last]
+		book.cover_url    = data[:cover_url]
 		book.tag_with(data[:tags])
 
 		book

--- a/app/models/google_books_client.rb
+++ b/app/models/google_books_client.rb
@@ -64,6 +64,7 @@ class GoogleBooksClient
 			:isbn			=> @isbn,
 			:title			=> doc["title"],
 			:description	=> doc["description"],
+			:cover_url		=>(doc["imageLinks"]["thumbnail"] rescue nil),
 			:tags			=> doc["categories"]
 		}
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -3,6 +3,7 @@
 <%= error_messages_for(:item).untaint %>
 
 <%= form_for :item, :url => { :action => 'update' }, :html => { :method => 'put' } do |f| -%>
+<%= f.hidden_field :cover_url if @item.cover_url.present? %>
 <table>
 
 	<tr>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -3,6 +3,7 @@
 <%= error_messages_for(:item).untaint %>
 
 <%= form_for :item, :url => polymorphic_path(@item) do |f| -%>
+<%= f.hidden_field :cover_url if @item.cover_url.present? %>
 <table>
 
 	<%= default_content_for :utility_fields do %><% end %>

--- a/config/application.yml
+++ b/config/application.yml
@@ -7,6 +7,8 @@ development: &defaults
   site_region_long: the Edmonton capital region
   # CSS Style file, a file app/assets/stylesheets or a full URL.
   css_style: andreas06.css
+  # Set this to false if you can't store images on your server (Heroku).
+  fetch_covers: true
   # Some tags are not acceptable.
   TAG_BLACKLIST: [general, Amazon.com, fuck, shit, crap]
   # Key for retrieving book info using the ISBNDB API.

--- a/db/migrate/016_add_image_url_to_book.rb
+++ b/db/migrate/016_add_image_url_to_book.rb
@@ -1,0 +1,5 @@
+class AddImageUrlToBook < ActiveRecord::Migration
+  def change
+    add_column :items, :cover_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 15) do
+ActiveRecord::Schema.define(:version => 16) do
 
   create_table "item_taggings", :force => true do |t|
     t.integer "thing_id", :null => false
@@ -28,6 +29,7 @@ ActiveRecord::Schema.define(:version => 15) do
     t.string   "author_last"
     t.integer  "current_loan_id"
     t.string   "lcc_number"
+    t.string   "cover_url"
   end
 
   create_table "loans", :force => true do |t|


### PR DESCRIPTION
This allows one to run the app on Heroku, where there is no filesystem persistence. Configurable with an `application.yml` option (default is to download and store images).
